### PR TITLE
Container logs

### DIFF
--- a/Taskfile-cli-docs.yml
+++ b/Taskfile-cli-docs.yml
@@ -50,41 +50,85 @@ tasks:
         generate_flags_table() {
           local source_file="$1"
           local flags_block
-          flags_block=$(awk '/^flags:/{found=1; next} found' "$source_file")
-          if [[ -n "$flags_block" && "$(echo "$flags_block" | xargs | tr '[:upper:]' '[:lower:]')" != "none" ]]; then
+          flags_block=$(sed -n '/^flags:/,$p' "$source_file" | sed '1d')
+
+          if [[ -n "$flags_block" && "$(echo "$flags_block" | xargs)" != "none" ]]; then
             echo "## Flags"
             echo ""
             echo "| Flag | Type | Description | Default |"
             echo "|------|------|-------------|---------|"
+            
             printf "%s\n" "$flags_block" | awk '
-              function output_flag() {
-                  if (name == "") return;
+              function process_buffer() {
+                  if (buffer == "") return;
+
+                  n_lines = split(buffer, lines, "\n");
+                  split(lines[1], flag_parts, /[ \t]+/);
+                  name = flag_parts[1];
+                  
+                  rest_of_first_line = "";
+                  for (i = 2; i <= length(flag_parts); i++) {
+                      rest_of_first_line = (rest_of_first_line == "" ? "" : rest_of_first_line " ") flag_parts[i];
+                  }
+
+                  if (n_lines > 1) {
+                      type = rest_of_first_line;
+                      if (type == "") { type = "bool"; }
+                      description = "";
+                      for (i = 2; i <= n_lines; i++) {
+                          line_content = lines[i];
+                          gsub(/^[ \t]+/, "", line_content);
+                          description = (description == "" ? "" : description " ") line_content;
+                      }
+                  } else {
+                      type = "bool";
+                      description = rest_of_first_line;
+                  }
+
                   default_val = "";
+                  default_found = 0;
+
                   if (match(description, /\(default "([^"]*)"\)/, m)) {
                       default_val = m[1];
                       gsub(/\(default "[^"]*"\)/, "", description);
+                      default_found = 1;
                   } else if (match(description, /\(default ([^)]*)\)/, m)) {
                       default_val = m[1];
                       gsub(/\(default [^)]*\)/, "", description);
+                      default_found = 1;
                   }
+
+                  if (!default_found) {
+                      if (type == "bool") {
+                          default_val = "false";
+                      } else if (type ~ /^(u?int|u?int(8|16|32|64))$/) {
+                          default_val = "0";
+                      } else if (type ~ /^float(32|64)$/) {
+                          default_val = "0.0";
+                      } else if (type == "duration") {
+                          default_val = "0s";
+                      }
+                  }
+                  
                   gsub(/^[ \t]+|[ \t]+$/, "", description);
                   gsub(/<[^>]+>/, "`&`", description);
-                  type_cell = (type == "") ? "" : "`" type "`";
-                  printf "| `%s` | %s | %s | %s |\n", name, type_cell, description, default_val;
+                  
+                  printf "| `%s` | `%s` | %s | %s |\n", name, type, description, default_val;
               }
+
               /^[[:space:]]*-/ {
-                  output_flag();
-                  name = $1;
-                  type = (NF > 1) ? $2 : "";
-                  description = "";
-                  next;
+                  process_buffer();
+                  buffer = $0;
+                  gsub(/^[ \t]+/, "", buffer);
               }
-              /^[[:space:]]{2,}/ {
-                  line_content = $0;
-                  gsub(/^[ \t]+/, "", line_content);
-                  description = (description == "") ? line_content : description " " line_content;
+
+              !/^[[:space:]]*-/ {
+                  buffer = buffer "\n" $0;
               }
-              END { output_flag(); }
+
+              END {
+                  process_buffer();
+              }
             '
           fi
         }

--- a/cmd/bx2cloud-api/main_linux.go
+++ b/cmd/bx2cloud-api/main_linux.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BenasB/bx2cloud/internal/api/container"
 	"github.com/BenasB/bx2cloud/internal/api/container/images"
+	"github.com/BenasB/bx2cloud/internal/api/container/logs"
 	"github.com/BenasB/bx2cloud/internal/api/interfaces"
 	"github.com/BenasB/bx2cloud/internal/api/introspection"
 	"github.com/BenasB/bx2cloud/internal/api/network"
@@ -50,9 +51,14 @@ func main() {
 		log.Fatalf("Failed to create the image puller: %v", err)
 	}
 
+	containerLogger, err := logs.NewFsLogger()
+	if err != nil {
+		log.Fatalf("Failed to create the container logger: %v", err)
+	}
+
 	pb.RegisterNetworkServiceServer(grpcServer, network.NewService(networkRepository, subnetworkRepository, networkConfigurator))
 	pb.RegisterSubnetworkServiceServer(grpcServer, subnetwork.NewService(subnetworkRepository, networkRepository, subnetworkConfigurator, ipamRepository))
-	pb.RegisterContainerServiceServer(grpcServer, container.NewService(containerRepository, subnetworkRepository, containerConfigurator, imagePuller, ipamRepository))
+	pb.RegisterContainerServiceServer(grpcServer, container.NewService(containerRepository, subnetworkRepository, containerConfigurator, imagePuller, ipamRepository, containerLogger))
 	pb.RegisterIntrospectionServiceServer(grpcServer, introspection.NewService())
 
 	log.Printf("Starting server on %s", address)

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,8 +8,8 @@
       "name": "bx2cloud",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/preset-classic": "3.8.1-canary-6365",
+        "@docusaurus/core": "^3.8.1",
+        "@docusaurus/preset-classic": "^3.8.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -17,9 +17,9 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.8.1-canary-6365",
-        "@docusaurus/tsconfig": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
+        "@docusaurus/module-type-aliases": "^3.8.1",
+        "@docusaurus/tsconfig": "^3.8.1",
+        "@docusaurus/types": "^3.8.1",
         "typescript": "~5.6.2"
       },
       "engines": {
@@ -68,92 +68,92 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.32.0.tgz",
-      "integrity": "sha512-HG/6Eib6DnJYm/B2ijWFXr4txca/YOuA4K7AsEU0JBrOZSB+RU7oeDyNBPi3c0v0UDDqlkBqM3vBU/auwZlglA==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.34.1.tgz",
+      "integrity": "sha512-M4zb6J7q+pg9V9Xk0k1WDgvupfCtXcxjKGTrNVYemiredLVGOmvVIPAUjg2rx4QmK7DWNApWLsieYwk7PAaOXw==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-common": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.32.0.tgz",
-      "integrity": "sha512-8Y9MLU72WFQOW3HArYv16+Wvm6eGmsqbxxM1qxtm0hvSASJbxCm+zQAZe5stqysTlcWo4BJ82KEH1PfgHbJAmQ==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.34.1.tgz",
+      "integrity": "sha512-h18zlL+bVUlbNE92olo1d/r6HQPkxhmP7yCpA1osERwpgC6F058kWm0O0aYdrHJIHtWBcs9aRqq7IkQSkpjPJg==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-common": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.32.0.tgz",
-      "integrity": "sha512-w8L+rgyXMCPBKmEdOT+RfgMrF0mT6HK60vPYWLz8DBs/P7yFdGo7urn99XCJvVLMSKXrIbZ2FMZ/i50nZTXnuQ==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.34.1.tgz",
+      "integrity": "sha512-otPWALs72KvmVuP0CN0DI6sqVx1jQWKi+/DgAiP8DysVMgiNlva3GDKTtAK6XVGlT08f4h32FNuL0yQODuCfKA==",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.32.0.tgz",
-      "integrity": "sha512-AdWfynhUeX7jz/LTiFU3wwzJembTbdLkQIOLs4n7PyBuxZ3jz4azV1CWbIP8AjUOFmul6uXbmYza+KqyS5CzOA==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.34.1.tgz",
+      "integrity": "sha512-SNDb5wuEpQFM6S5Shk2iytLMusvGycm9uTuYh7cGa1h3U7O65OjjjIgQ0lLY5HPybHNtmXr4Zh/EZ23pZvAJHg==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-common": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.32.0.tgz",
-      "integrity": "sha512-bTupJY4xzGZYI4cEQcPlSjjIEzMvv80h7zXGrXY1Y0KC/n/SLiMv84v7Uy+B6AG1Kiy9FQm2ADChBLo1uEhGtQ==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.34.1.tgz",
+      "integrity": "sha512-T8z9KqYJOup83Hw0mgICYWfJoLh//FNWbf4roFd95ZJzZ4v1cN/hvr7Eqml1qWMoCkJb4y/XQjrXsJ6Y9XnMLw==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-common": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.32.0.tgz",
-      "integrity": "sha512-if+YTJw1G3nDKL2omSBjQltCHUQzbaHADkcPQrGFnIGhVyHU3Dzq4g46uEv8mrL5sxL8FjiS9LvekeUlL2NRqw==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.34.1.tgz",
+      "integrity": "sha512-YA0kC4CwO1mc1dliNgbFgToweRa7Uihjz3izEaV4cXninF1v4SaOrPkQUsiFPprAffjMzOUoT7vahQZ/HZyiKQ==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-common": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.32.0.tgz",
-      "integrity": "sha512-kmK5nVkKb4DSUgwbveMKe4X3xHdMsPsOVJeEzBvFJ+oS7CkBPmpfHAEq+CcmiPJs20YMv6yVtUT9yPWL5WgAhg==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.34.1.tgz",
+      "integrity": "sha512-bt5hC9vvjaKvdvsgzfXJ42Sl3qjQqoi/FD8V7HOQgtNFhwSauZOlgLwFoUiw67sM+r7ehF7QDk5WRDgY7fAkIg==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-common": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -165,75 +165,75 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.32.0.tgz",
-      "integrity": "sha512-PZTqjJbx+fmPuT2ud1n4vYDSF1yrT//vOGI9HNYKNA0PM0xGUBWigf5gRivHsXa3oBnUlTyHV9j7Kqx5BHbVHQ==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.34.1.tgz",
+      "integrity": "sha512-QLxiBskQxFGzPqKZvBNEvNN95kgDCbBd2X29ZGfh6Sr2QOSU34US6Z9x2duiF4o9FwsB0i6eQ2c9vHfuH0lAQg==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-common": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.32.0.tgz",
-      "integrity": "sha512-kYYoOGjvNQAmHDS1v5sBj+0uEL9RzYqH/TAdq8wmcV+/22weKt/fjh+6LfiqkS1SCZFYYrwGnirrUhUM36lBIQ==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.34.1.tgz",
+      "integrity": "sha512-NteCvWcWXXdnPGyZH8rXHslcf2pM1WGDNMGNZFXLFtOt1Gf1Tjy2t0NZLp+Mxap3JMV4mbYmactbXrvpQf/lLA==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-common": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.32.0.tgz",
-      "integrity": "sha512-jyIBLdskjPAL7T1g57UMfUNx+PzvYbxKslwRUKBrBA6sNEsYCFdxJAtZSLUMmw6MC98RDt4ksmEl5zVMT5bsuw==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.34.1.tgz",
+      "integrity": "sha512-UdgDSrunLIBAAAxQlYLXYLnYFN4wkzkrAYx+wMLEk/pzASWyza3BkecbUFVqoYOBIgwo7Mt4iymzVtFkzL2uCQ==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-common": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.32.0.tgz",
-      "integrity": "sha512-eDp14z92Gt6JlFgiexImcWWH+Lk07s/FtxcoDaGrE4UVBgpwqOO6AfQM6dXh1pvHxlDFbMJihHc/vj3gBhPjqQ==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.34.1.tgz",
+      "integrity": "sha512-567LfFTc9VOiPtuySQohoqaWMeohYWbXK71aMSin+SLMgeKX7hz5LrVmkmMQj9udwWK6/mtHEYZGPYHSuXpLQg==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0"
+        "@algolia/client-common": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.32.0.tgz",
-      "integrity": "sha512-rnWVglh/K75hnaLbwSc2t7gCkbq1ldbPgeIKDUiEJxZ4mlguFgcltWjzpDQ/t1LQgxk9HdIFcQfM17Hid3aQ6Q==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.34.1.tgz",
+      "integrity": "sha512-YRbygPgGBEik5U593JvyjgxFjcsyZMR25eIQxNHvSQumdAzt5A4E4Idw3yXnwhrmMdjML54ZXT7EAjnTjWy8Xw==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0"
+        "@algolia/client-common": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.32.0.tgz",
-      "integrity": "sha512-LbzQ04+VLkzXY4LuOzgyjqEv/46Gwrk55PldaglMJ4i4eDXSRXGKkwJpXFwsoU+c1HMQlHIyjJBhrfsfdyRmyQ==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.34.1.tgz",
+      "integrity": "sha512-o0mqRYbS82Rt4DE02Od7RL6pNtV7oSxScPuIw8LW4aqO2V5eCF05Pry/SnUgcI/Vb2QCYC66hytBCqzyC/toZA==",
       "dependencies": {
-        "@algolia/client-common": "5.32.0"
+        "@algolia/client-common": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -574,12 +574,12 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.6"
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1423,9 +1423,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.0.tgz",
-      "integrity": "sha512-LOAozRVbqxEVjSKfhGnuLoE4Kz4Oc5UJzuvFUhSsQzdCdaAQu06mG8zDv2GFSerM62nImUZ7K92vxnQcLSDlCQ==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
+      "integrity": "sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1790,9 +1790,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.0.tgz",
-      "integrity": "sha512-nlIXnSqLcBij8K8TtkxbBJgfzfvi75V1pAKSM7dUXejGw12vJAqez74jZrHTsJ3Z+Aczc5Q/6JgNjKRMsVU44g==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.2.tgz",
+      "integrity": "sha512-FVFaVs2/dZgD3Y9ZD+AKNKjyGKzwu0C54laAXWUXgLcVXcCX6YZ6GhK2cp7FogSN2OA0Fu+QT8dP3FUdo9ShSQ==",
       "dependencies": {
         "core-js-pure": "^3.43.0"
       },
@@ -1831,9 +1831,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
-      "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -2980,9 +2980,9 @@
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-O/xqt+EeT+ddDbbkKFxF8q0Td44pov8w8uvKrNQjACQLyEMPPEv8tiobUC+DtpSDN9j/bcUEC6/QFaaJy5MM7Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1.tgz",
+      "integrity": "sha512-3brkJrml8vUbn9aeoZUlJfsI/GqyFcDgQJwQkmBtclJgWDEQBKKeagZfOgx0WfUQhagL1sQLNW0iBdxnI863Uw==",
       "dependencies": {
         "@babel/core": "^7.25.9",
         "@babel/generator": "^7.25.9",
@@ -2994,8 +2994,8 @@
         "@babel/runtime": "^7.25.9",
         "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3005,16 +3005,16 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-TzZlmA6wKIX+UUVklLeMuJLgWCU8GmuqPYRdoWMy0zAl3LAwXa3I1e77Z7PoHWe8HyN0n37A2+fuP1DZHkEv3g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.1.tgz",
+      "integrity": "sha512-/z4V0FRoQ0GuSLToNjOSGsk6m2lQUG4FRn8goOVoZSRsTrU8YR2aJacX5K3RG18EaX9b+52pN4m1sL3MQZVsQA==",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.8.1-canary-6365",
-        "@docusaurus/cssnano-preset": "3.8.1-canary-6365",
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/cssnano-preset": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -3047,17 +3047,17 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-+n6qZd4+As06rPc8Eu5viBDzOYznrwtiot3VvL/brVHQehOyO9gkpE07q7ruZybnwdHuJbFZKUhst3RvB4kSRQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==",
       "dependencies": {
-        "@docusaurus/babel": "3.8.1-canary-6365",
-        "@docusaurus/bundler": "3.8.1-canary-6365",
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/mdx-loader": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-common": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/bundler": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3107,9 +3107,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-v8ptT6QfEbslcHEKjgv8kivB47wPr4ogXCImmetuKCKTn8pS9ACTB4j6aB1CkTzL2zOIV94+DwZ+5FSyNJlaog==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.1.tgz",
+      "integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
         "postcss": "^8.5.4",
@@ -3121,9 +3121,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-PtoriH+UBRiKpisARvKQFag7fIioBArz3LIl1L5wT/msvWu4o5R9HiEDIVscduKdpTgfsbUrChGHtWMxbWv3aw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1.tgz",
+      "integrity": "sha512-2wjeGDhKcExEmjX8k1N/MRDiPKXGF2Pg+df/bDDPnnJWHXnVEZxXj80d6jcxp1Gpnksl0hF8t/ZQw9elqj2+ww==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -3133,13 +3133,13 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-qQqHTTFGjMDdq4W/cYEvM5565a72kmSCa8FWZxXHddK4nXa1CDgOGJIsuMThxsV8FXCI2dFlmk1Jp4Sng2eFeg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
+      "integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
       "dependencies": {
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3171,11 +3171,11 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-jAVNqvNJBlbDv/jzCQyUTL6TH5n0L3Ud1m2W/DHkp9JhQAcBSUgTeDKMPSNKJd60hnx33wn2SHwPPaBnqVHq1Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1.tgz",
+      "integrity": "sha512-6xhvAJiXzsaq3JdosS7wbRt/PwEPWHr9eM4YNYqVlbgG1hSK3uQDXTVvQktasp3VO6BmfYWPozueLWuj4gB+vg==",
       "dependencies": {
-        "@docusaurus/types": "3.8.1-canary-6365",
+        "@docusaurus/types": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3189,18 +3189,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-s5fh9UFs0K1JqUV2iilmLplo9zLFqe7GQ0qOA0PNr4CJQZXZG7wG8OvN9U6ZQLNLd2KRlDvkyBwoQXHtui3dHw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1.tgz",
+      "integrity": "sha512-vNTpMmlvNP9n3hGEcgPaXyvTljanAKIUkuG9URQ1DeuDup0OR7Ltvoc8yrmH+iMZJbcQGhUJF+WjHLwuk8HSdw==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/mdx-loader": "3.8.1-canary-6365",
-        "@docusaurus/theme-common": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-common": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -3222,19 +3222,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-J/MZLnyvua+VX11DQAZNVp3xQDbVZYlGE/bKwQ4M7tJnlGUOtTPKQlje9e2IvXoAUHAJZm0HbH81I9lIM63pAA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1.tgz",
+      "integrity": "sha512-oByRkSZzeGNQByCMaX+kif5Nl2vmtj2IHQI2fWjCfCootsdKZDPFLonhIp5s3IGJO7PLUfe0POyw0Xh/RrGXJA==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/mdx-loader": "3.8.1-canary-6365",
-        "@docusaurus/module-type-aliases": "3.8.1-canary-6365",
-        "@docusaurus/theme-common": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-common": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -3254,15 +3254,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-IIIWH59jIBMvoBB6dmLx63EuqrDndcWx9QcUdC1FQL+6B64o8OGynaUauIRnPhZFYbJ9SXgRH8JoauO/Nrr/tw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.1.tgz",
+      "integrity": "sha512-a+V6MS2cIu37E/m7nDJn3dcxpvXb6TvgdNI22vJX8iUTp8eoMoPa0VArEbWvCxMY/xdC26WzNv4wZ6y0iIni/w==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/mdx-loader": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -3276,14 +3276,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-R9PGIvgZ1ksJMOkf9ptipeMOcMbSe38DuVm5AYQRW5xsGEFB9JmNm+wmNuhsTyvfYRywKJF6tLkQxTxicRPOCQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.1.tgz",
+      "integrity": "sha512-VQ47xRxfNKjHS5ItzaVXpxeTm7/wJLFMOPo1BkmoMG4Cuz4nuI+Hs62+RMk1OqVog68Swz66xVPK8g9XTrBKRw==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3291,13 +3291,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-moxzXKt30d2BInMn+yN2Wmh2rwpvijxtqEH+gJYJO24XHUMcDE1hAADItVHL9UEexBwTwJiCR//typyo6Z5FRw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.1.tgz",
+      "integrity": "sha512-nT3lN7TV5bi5hKMB7FK8gCffFTBSsBsAfV84/v293qAmnHOyg1nr9okEw8AiwcO3bl9vije5nsUvP0aRl2lpaw==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
@@ -3311,13 +3311,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-vdY10gxX9n6LcX9RKqHQOJViLgJmahArA6Ot1mVMw0HzINnJvxxeqaWZZ0AnSL7N+3G2YUbdYNRa39ly3RKQxA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.1.tgz",
+      "integrity": "sha512-Hrb/PurOJsmwHAsfMDH6oVpahkEGsx7F8CWMjyP/dw1qjqmdS9rcV1nYCGlM8nOtD3Wk/eaThzUB5TSZsGz+7Q==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3329,13 +3329,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-Mlotbip8M25F+5DkJmGoPvO6zNz2opMo95iafO4ktELCGKnmj0YmVr9FgkN3jO3YKaPMTJI7IR4lbkRV/+EnBQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.1.tgz",
+      "integrity": "sha512-tKE8j1cEZCh8KZa4aa80zpSTxsC2/ZYqjx6AAfd8uA8VHZVw79+7OTEP2PoWi0uL5/1Is0LF5Vwxd+1fz5HlKg==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -3348,13 +3348,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-dF8rv4M3zM+5QCzxf7XhwfES0GScJnL6WfTHVf2acaoX2ebz5NpOc0Dh/j9MI/gKgKVZn9F+fxZavxuDpgHXrA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.1.tgz",
+      "integrity": "sha512-iqe3XKITBquZq+6UAXdb1vI0fPY5iIOitVjPQ581R1ZKpHr0qe+V6gVOrrcOHixPDD/BUKdYwkxFjpNiEN+vBw==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3366,16 +3366,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-Nl699sXmk3y2O+ikvmt4QGTaZZg0/f/8t1DBRv+EbNgl4Glos91lCHxMEq79jBpV1gPSpWUx4J+/3TzZBkRcwg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1.tgz",
+      "integrity": "sha512-+9YV/7VLbGTq8qNkjiugIelmfUEVkTyLe6X8bWq7K5qPvGXAjno27QAfFq63mYfFFbJc7z+pudL63acprbqGzw==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-common": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3389,14 +3389,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-wJ0885iR5bPEDWWKmcjKnf0TbRxnNIXLIauqd/QyiVFThcxzCoqMO1kTB1cQmyXzgvaOeIfEeiVFlMdLBbO1Ig==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.1.tgz",
+      "integrity": "sha512-rW0LWMDsdlsgowVwqiMb/7tANDodpy1wWPwCcamvhY7OECReN3feoFwLjd/U4tKjNY3encj0AJSTxJA+Fpe+Gw==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -3411,25 +3411,25 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-dVV66N82pb6oldd3qj6/+YNgOVEOjQP+O2ZobTO0kHoGfm3Y4q3HuJuc5mkAlQJQanrFCfvGM1cVo0ltFU8Gig==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz",
+      "integrity": "sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/plugin-content-blog": "3.8.1-canary-6365",
-        "@docusaurus/plugin-content-docs": "3.8.1-canary-6365",
-        "@docusaurus/plugin-content-pages": "3.8.1-canary-6365",
-        "@docusaurus/plugin-css-cascade-layers": "3.8.1-canary-6365",
-        "@docusaurus/plugin-debug": "3.8.1-canary-6365",
-        "@docusaurus/plugin-google-analytics": "3.8.1-canary-6365",
-        "@docusaurus/plugin-google-gtag": "3.8.1-canary-6365",
-        "@docusaurus/plugin-google-tag-manager": "3.8.1-canary-6365",
-        "@docusaurus/plugin-sitemap": "3.8.1-canary-6365",
-        "@docusaurus/plugin-svgr": "3.8.1-canary-6365",
-        "@docusaurus/theme-classic": "3.8.1-canary-6365",
-        "@docusaurus/theme-common": "3.8.1-canary-6365",
-        "@docusaurus/theme-search-algolia": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365"
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/plugin-css-cascade-layers": "3.8.1",
+        "@docusaurus/plugin-debug": "3.8.1",
+        "@docusaurus/plugin-google-analytics": "3.8.1",
+        "@docusaurus/plugin-google-gtag": "3.8.1",
+        "@docusaurus/plugin-google-tag-manager": "3.8.1",
+        "@docusaurus/plugin-sitemap": "3.8.1",
+        "@docusaurus/plugin-svgr": "3.8.1",
+        "@docusaurus/theme-classic": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-search-algolia": "3.8.1",
+        "@docusaurus/types": "3.8.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -3440,23 +3440,23 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-9hkXXH7pvZ8Pj5oOUuAYar5zYC095ex44mNeJUV3ZoFoN3EA/kw6uRJoshvyZXB45RW84LHLIHLdaEg/cXPIWA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.1.tgz",
+      "integrity": "sha512-bqDUCNqXeYypMCsE1VcTXSI1QuO4KXfx8Cvl6rYfY0bhhqN6d2WZlRkyLg/p6pm+DzvanqHOyYlqdPyP0iz+iw==",
       "dependencies": {
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/mdx-loader": "3.8.1-canary-6365",
-        "@docusaurus/module-type-aliases": "3.8.1-canary-6365",
-        "@docusaurus/plugin-content-blog": "3.8.1-canary-6365",
-        "@docusaurus/plugin-content-docs": "3.8.1-canary-6365",
-        "@docusaurus/plugin-content-pages": "3.8.1-canary-6365",
-        "@docusaurus/theme-common": "3.8.1-canary-6365",
-        "@docusaurus/theme-translations": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-common": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -3480,14 +3480,14 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-Dccj4PX/rvzYM6d4KTQJdfBQRxGwhOnb+A+xTUcLGBo/N3pt7wHNWPvxXJ0OC2xFREYn+NMeOVEjqhhMpzfyTA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.1.tgz",
+      "integrity": "sha512-UswMOyTnPEVRvN5Qzbo+l8k4xrd5fTFu2VPPfD6FcW/6qUtVLmJTQCktbAL3KJ0BVXGm5aJXz/ZrzqFuZERGPw==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.8.1-canary-6365",
-        "@docusaurus/module-type-aliases": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-common": "3.8.1-canary-6365",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3507,18 +3507,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-pqok7IIuTIFgxEu8eMAMlPLekf5CKl10qwF9Dk5J2Shwv9uMiRoFTXzUtf9h9sNdurUaGTKWVJ9pXX9fba2zRA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.1.tgz",
+      "integrity": "sha512-NBFH5rZVQRAQM087aYSRKQ9yGEK9eHd+xOxQjqNpxMiV85OhJDD4ZGz6YJIod26Fbooy54UWVdzNU0TFeUUUzQ==",
       "dependencies": {
         "@docsearch/react": "^3.9.0",
-        "@docusaurus/core": "3.8.1-canary-6365",
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/plugin-content-docs": "3.8.1-canary-6365",
-        "@docusaurus/theme-common": "3.8.1-canary-6365",
-        "@docusaurus/theme-translations": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-validation": "3.8.1-canary-6365",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "algoliasearch": "^5.17.1",
         "algoliasearch-helper": "^3.22.6",
         "clsx": "^2.0.0",
@@ -3537,9 +3537,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-X4F3/lXW25xk2ol9BSbFoqTcNK3vBZjrN5YZObhTWBcjdhZ2EgxkLsSBe9mVVlJE4yabUWx2Cyfvq45wYUXsvw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.1.tgz",
+      "integrity": "sha512-OTp6eebuMcf2rJt4bqnvuwmm3NVXfzfYejL+u/Y1qwKhZPrjPoKWfk1CbOP5xH5ZOPkiAsx4dHdQBRJszK3z2g==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3549,19 +3549,18 @@
       }
     },
     "node_modules/@docusaurus/tsconfig": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-8ECzBtp1YpynMSkVjC/yj9fqGJgNQ5RBUbksDgT/qAm3YLKdilH33FIy09ovaMWsakCiXyY81Q/Myfa3yFKkAw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.8.1.tgz",
+      "integrity": "sha512-XBWCcqhRHhkhfolnSolNL+N7gj3HVE3CoZVqnVjfsMzCoOsuQw2iCLxVVHtO+rePUUfouVZHURDgmqIySsF66A==",
       "dev": true
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-1JqU1x2M7PdMEYl5QZnBD2UG+cKJ5A5eYq0/zykEnbjSf++H0u/gwz6NBdlQlwM/H+QnwlqYt35BtgImMRCxdA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.1.tgz",
+      "integrity": "sha512-ZPdW5AB+pBjiVrcLuw3dOS6BFlrG0XkS2lDGsj8TizcnREQg3J8cjsgfDviszOk4CweNfwo1AEELJkYaMUuOPg==",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
         "@types/react": "*",
         "commander": "^5.1.0",
         "joi": "^17.9.2",
@@ -3589,13 +3588,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-hgoDQWcXtcGL+IfQPlNSD3lVE+jmwbcG1OxMdOFoVx5FdJZbQqm5ryboUCLsctJc/HcAcTWmDaiFzIzwfTUKpw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.1.tgz",
+      "integrity": "sha512-P1ml0nvOmEFdmu0smSXOqTS1sxU5tqvnc0dA4MTKV39kye+bhQnjkIKEE18fNOvxjyB86k8esoCIFM3x4RykOQ==",
       "dependencies": {
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/types": "3.8.1-canary-6365",
-        "@docusaurus/utils-common": "3.8.1-canary-6365",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "escape-string-regexp": "^4.0.0",
         "execa": "5.1.1",
         "file-loader": "^6.2.0",
@@ -3620,11 +3619,11 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-6Mze8fU2QeM8xjxol2ku6H705HbLs9kr1H8ZAV0io1cvbyHlU0aDG/TYo6TSSsht+yYwE60qWWaiSMvUbXcrKA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.1.tgz",
+      "integrity": "sha512-zTZiDlvpvoJIrQEEd71c154DkcriBecm4z94OzEE9kz7ikS3J+iSlABhFXM45mZ0eN5pVqqr7cs60+ZlYLewtg==",
       "dependencies": {
-        "@docusaurus/types": "3.8.1-canary-6365",
+        "@docusaurus/types": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3632,13 +3631,13 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.8.1-canary-6365",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.1-canary-6365.tgz",
-      "integrity": "sha512-55UV3p+zsq6Nn03AIlYlaAon+eYhNOl+LM33PD8+bREcLUEFDgQ+1h0vMWglxUvwZWaHfeWh+Ow7tTzHLOVIbw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.1.tgz",
+      "integrity": "sha512-gs5bXIccxzEbyVecvxg6upTwaUbfa0KMmTj7HhHzc016AGyxH2o73k1/aOD0IFrdCsfJNt37MqNI47s2MgRZMA==",
       "dependencies": {
-        "@docusaurus/logger": "3.8.1-canary-6365",
-        "@docusaurus/utils": "3.8.1-canary-6365",
-        "@docusaurus/utils-common": "3.8.1-canary-6365",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4792,23 +4791,23 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.32.0.tgz",
-      "integrity": "sha512-84xBncKNPBK8Ae89F65+SyVcOihrIbm/3N7to+GpRBHEUXGjA3ydWTMpcRW6jmFzkBQ/eqYy/y+J+NBpJWYjBg==",
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.34.1.tgz",
+      "integrity": "sha512-s70HlfBgswgEdmCYkUJG8i/ULYhbkk8N9+N8JsWUwszcp7eauPEr5tIX4BY0qDGeKWQ/qZvmt4mxwTusYY23sg==",
       "dependencies": {
-        "@algolia/client-abtesting": "5.32.0",
-        "@algolia/client-analytics": "5.32.0",
-        "@algolia/client-common": "5.32.0",
-        "@algolia/client-insights": "5.32.0",
-        "@algolia/client-personalization": "5.32.0",
-        "@algolia/client-query-suggestions": "5.32.0",
-        "@algolia/client-search": "5.32.0",
-        "@algolia/ingestion": "1.32.0",
-        "@algolia/monitoring": "1.32.0",
-        "@algolia/recommend": "5.32.0",
-        "@algolia/requester-browser-xhr": "5.32.0",
-        "@algolia/requester-fetch": "5.32.0",
-        "@algolia/requester-node-http": "5.32.0"
+        "@algolia/client-abtesting": "5.34.1",
+        "@algolia/client-analytics": "5.34.1",
+        "@algolia/client-common": "5.34.1",
+        "@algolia/client-insights": "5.34.1",
+        "@algolia/client-personalization": "5.34.1",
+        "@algolia/client-query-suggestions": "5.34.1",
+        "@algolia/client-search": "5.34.1",
+        "@algolia/ingestion": "1.34.1",
+        "@algolia/monitoring": "1.34.1",
+        "@algolia/recommend": "5.34.1",
+        "@algolia/requester-browser-xhr": "5.34.1",
+        "@algolia/requester-fetch": "5.34.1",
+        "@algolia/requester-node-http": "5.34.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -14719,11 +14718,11 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,8 +15,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.8.1-canary-6365",
-    "@docusaurus/preset-classic": "3.8.1-canary-6365",
+    "@docusaurus/core": "^3.8.1",
+    "@docusaurus/preset-classic": "^3.8.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -24,9 +24,9 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.8.1-canary-6365",
-    "@docusaurus/tsconfig": "3.8.1-canary-6365",
-    "@docusaurus/types": "3.8.1-canary-6365",
+    "@docusaurus/module-type-aliases": "^3.8.1",
+    "@docusaurus/tsconfig": "^3.8.1",
+    "@docusaurus/types": "^3.8.1",
     "typescript": "~5.6.2"
   },
   "browserslist": {

--- a/internal/api/container/logs/fs.go
+++ b/internal/api/container/logs/fs.go
@@ -1,0 +1,29 @@
+package logs
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+var _ Logger = &fsLogger{}
+
+type fsLogger struct {
+	root string
+}
+
+func NewFsLogger() (Logger, error) {
+	root := "/var/log/bx2cloud"
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, err
+	}
+
+	return &fsLogger{
+		root: root,
+	}, nil
+}
+
+func (l *fsLogger) Init(containerId uint32) (*os.File, error) {
+	idString := strconv.FormatInt(int64(containerId), 10)
+	return os.OpenFile(filepath.Join(l.root, idString), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+}

--- a/internal/api/container/logs/fs.go
+++ b/internal/api/container/logs/fs.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -26,4 +27,9 @@ func NewFsLogger() (Logger, error) {
 func (l *fsLogger) Init(containerId uint32) (*os.File, error) {
 	idString := strconv.FormatInt(int64(containerId), 10)
 	return os.OpenFile(filepath.Join(l.root, idString), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+}
+
+func (l *fsLogger) Get(containerId uint32) (io.ReadCloser, error) {
+	idString := strconv.FormatInt(int64(containerId), 10)
+	return os.Open(filepath.Join(l.root, idString))
 }

--- a/internal/api/container/logs/fs.go
+++ b/internal/api/container/logs/fs.go
@@ -1,7 +1,6 @@
 package logs
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -29,7 +28,7 @@ func (l *fsLogger) Init(containerId uint32) (*os.File, error) {
 	return os.OpenFile(filepath.Join(l.root, idString), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 }
 
-func (l *fsLogger) Get(containerId uint32) (io.ReadCloser, error) {
+func (l *fsLogger) Get(containerId uint32) (*os.File, error) {
 	idString := strconv.FormatInt(int64(containerId), 10)
 	return os.Open(filepath.Join(l.root, idString))
 }

--- a/internal/api/container/logs/fs.go
+++ b/internal/api/container/logs/fs.go
@@ -33,3 +33,8 @@ func (l *fsLogger) Get(containerId uint32) (io.ReadCloser, error) {
 	idString := strconv.FormatInt(int64(containerId), 10)
 	return os.Open(filepath.Join(l.root, idString))
 }
+
+func (l *fsLogger) Remove(containerId uint32) error {
+	idString := strconv.FormatInt(int64(containerId), 10)
+	return os.Remove(filepath.Join(l.root, idString))
+}

--- a/internal/api/container/logs/logger.go
+++ b/internal/api/container/logs/logger.go
@@ -1,7 +1,11 @@
 package logs
 
-import "os"
+import (
+	"io"
+	"os"
+)
 
 type Logger interface {
 	Init(containerId uint32) (*os.File, error)
+	Get(containerId uint32) (io.ReadCloser, error)
 }

--- a/internal/api/container/logs/logger.go
+++ b/internal/api/container/logs/logger.go
@@ -1,12 +1,11 @@
 package logs
 
 import (
-	"io"
 	"os"
 )
 
 type Logger interface {
 	Init(containerId uint32) (*os.File, error)
 	Remove(containerId uint32) error
-	Get(containerId uint32) (io.ReadCloser, error)
+	Get(containerId uint32) (*os.File, error)
 }

--- a/internal/api/container/logs/logger.go
+++ b/internal/api/container/logs/logger.go
@@ -1,0 +1,7 @@
+package logs
+
+import "os"
+
+type Logger interface {
+	Init(containerId uint32) (*os.File, error)
+}

--- a/internal/api/container/logs/logger.go
+++ b/internal/api/container/logs/logger.go
@@ -7,5 +7,6 @@ import (
 
 type Logger interface {
 	Init(containerId uint32) (*os.File, error)
+	Remove(containerId uint32) error
 	Get(containerId uint32) (io.ReadCloser, error)
 }

--- a/internal/api/container/repository_linux.go
+++ b/internal/api/container/repository_linux.go
@@ -278,6 +278,7 @@ func (r *libcontainerRepository) Create(creationModel *interfaces.ContainerCreat
 		UID:    int(creationModel.Spec.Process.User.UID),
 		GID:    int(creationModel.Spec.Process.User.GID),
 		Stdout: creationModel.Stdout,
+		Stderr: creationModel.Stdout,
 		// Not everything is mapped here (yet?)
 		Init: true,
 	}

--- a/internal/api/container/service.go
+++ b/internal/api/container/service.go
@@ -3,7 +3,6 @@ package container
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"time"
 
@@ -286,39 +285,6 @@ func (s *service) Stop(ctx context.Context, req *pb.ContainerIdentificationReque
 	}
 
 	return mapModelToDto(container)
-}
-
-func (s *service) Logs(req *pb.ContainerLogsRequest, stream grpc.ServerStreamingServer[pb.ContainerLogsResponse]) error {
-	container, err := s.repository.Get(req.Identification.Id)
-	if err != nil {
-		return err
-	}
-
-	data := container.GetData()
-
-	r, err := s.containerLogger.Get(data.Id)
-	if err != nil {
-		return fmt.Errorf("failed to open container logs: %w", err)
-	}
-	defer r.Close()
-
-	buf := make([]byte, 8192)
-	for {
-		n, err := r.Read(buf)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		if err := stream.Send(&pb.ContainerLogsResponse{
-			Content: buf[:n],
-		}); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func mapModelToDto(container interfaces.ContainerModel) (*pb.Container, error) {

--- a/internal/api/container/service.go
+++ b/internal/api/container/service.go
@@ -82,6 +82,10 @@ func (s *service) Delete(ctx context.Context, req *pb.ContainerIdentificationReq
 		return nil, err
 	}
 
+	if err := s.containerLogger.Remove(data.Id); err != nil {
+		return nil, err
+	}
+
 	if err := s.imagePuller.RemoveRootFs(data.Id); err != nil {
 		return nil, err
 	}

--- a/internal/api/interfaces/models.go
+++ b/internal/api/interfaces/models.go
@@ -59,4 +59,5 @@ type ContainerCreationModel struct {
 	CreatedAt               time.Time
 	EntrypointCustomization *ContainerProcessCustomization
 	Spec                    *runspecs.Spec
+	Stdout                  *os.File
 }

--- a/internal/api/pb/container.pb.go
+++ b/internal/api/pb/container.pb.go
@@ -507,6 +507,102 @@ func (*ContainerExecResponse_Stdout) isContainerExecResponse_Output() {}
 
 func (*ContainerExecResponse_ExitCode) isContainerExecResponse_Output() {}
 
+type ContainerLogsRequest struct {
+	state          protoimpl.MessageState          `protogen:"open.v1"`
+	Identification *ContainerIdentificationRequest `protobuf:"bytes,1,opt,name=identification,proto3" json:"identification,omitempty"`
+	Follow         bool                            `protobuf:"varint,2,opt,name=follow,proto3" json:"follow,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ContainerLogsRequest) Reset() {
+	*x = ContainerLogsRequest{}
+	mi := &file_container_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContainerLogsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerLogsRequest) ProtoMessage() {}
+
+func (x *ContainerLogsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_container_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerLogsRequest.ProtoReflect.Descriptor instead.
+func (*ContainerLogsRequest) Descriptor() ([]byte, []int) {
+	return file_container_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ContainerLogsRequest) GetIdentification() *ContainerIdentificationRequest {
+	if x != nil {
+		return x.Identification
+	}
+	return nil
+}
+
+func (x *ContainerLogsRequest) GetFollow() bool {
+	if x != nil {
+		return x.Follow
+	}
+	return false
+}
+
+type ContainerLogsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Content       []byte                 `protobuf:"bytes,1,opt,name=content,proto3" json:"content,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ContainerLogsResponse) Reset() {
+	*x = ContainerLogsResponse{}
+	mi := &file_container_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContainerLogsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerLogsResponse) ProtoMessage() {}
+
+func (x *ContainerLogsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_container_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerLogsResponse.ProtoReflect.Descriptor instead.
+func (*ContainerLogsResponse) Descriptor() ([]byte, []int) {
+	return file_container_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ContainerLogsResponse) GetContent() []byte {
+	if x != nil {
+		return x.Content
+	}
+	return nil
+}
+
 var File_container_proto protoreflect.FileDescriptor
 
 const file_container_proto_rawDesc = "" +
@@ -551,7 +647,12 @@ const file_container_proto_rawDesc = "" +
 	"\x15ContainerExecResponse\x12\x18\n" +
 	"\x06stdout\x18\x01 \x01(\fH\x00R\x06stdout\x12\x1d\n" +
 	"\texit_code\x18\x02 \x01(\x05H\x00R\bexitCodeB\b\n" +
-	"\x06output2\xfa\x03\n" +
+	"\x06output\"\x80\x01\n" +
+	"\x14ContainerLogsRequest\x12P\n" +
+	"\x0eidentification\x18\x01 \x01(\v2(.bx2cloud.ContainerIdentificationRequestR\x0eidentification\x12\x16\n" +
+	"\x06follow\x18\x02 \x01(\bR\x06follow\"1\n" +
+	"\x15ContainerLogsResponse\x12\x18\n" +
+	"\acontent\x18\x01 \x01(\fR\acontent2\xc5\x04\n" +
 	"\x10ContainerService\x12D\n" +
 	"\x03Get\x12(.bx2cloud.ContainerIdentificationRequest\x1a\x13.bx2cloud.Container\x125\n" +
 	"\x04List\x12\x16.google.protobuf.Empty\x1a\x13.bx2cloud.Container0\x01\x12A\n" +
@@ -559,7 +660,8 @@ const file_container_proto_rawDesc = "" +
 	"\x06Delete\x12(.bx2cloud.ContainerIdentificationRequest\x1a\x16.google.protobuf.Empty\x12K\n" +
 	"\x04Exec\x12\x1e.bx2cloud.ContainerExecRequest\x1a\x1f.bx2cloud.ContainerExecResponse(\x010\x01\x12F\n" +
 	"\x05Start\x12(.bx2cloud.ContainerIdentificationRequest\x1a\x13.bx2cloud.Container\x12E\n" +
-	"\x04Stop\x12(.bx2cloud.ContainerIdentificationRequest\x1a\x13.bx2cloud.ContainerB,Z*github.com/BenasB/bx2cloud/internal/api/pbb\x06proto3"
+	"\x04Stop\x12(.bx2cloud.ContainerIdentificationRequest\x1a\x13.bx2cloud.Container\x12I\n" +
+	"\x04Logs\x12\x1e.bx2cloud.ContainerLogsRequest\x1a\x1f.bx2cloud.ContainerLogsResponse0\x01B,Z*github.com/BenasB/bx2cloud/internal/api/pbb\x06proto3"
 
 var (
 	file_container_proto_rawDescOnce sync.Once
@@ -573,7 +675,7 @@ func file_container_proto_rawDescGZIP() []byte {
 	return file_container_proto_rawDescData
 }
 
-var file_container_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_container_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_container_proto_goTypes = []any{
 	(*ContainerIdentificationRequest)(nil),     // 0: bx2cloud.ContainerIdentificationRequest
 	(*ContainerCreationRequest)(nil),           // 1: bx2cloud.ContainerCreationRequest
@@ -581,33 +683,38 @@ var file_container_proto_goTypes = []any{
 	(*ContainerExecRequest)(nil),               // 3: bx2cloud.ContainerExecRequest
 	(*ContainerExecInitializationRequest)(nil), // 4: bx2cloud.ContainerExecInitializationRequest
 	(*ContainerExecResponse)(nil),              // 5: bx2cloud.ContainerExecResponse
-	(*timestamppb.Timestamp)(nil),              // 6: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                      // 7: google.protobuf.Empty
+	(*ContainerLogsRequest)(nil),               // 6: bx2cloud.ContainerLogsRequest
+	(*ContainerLogsResponse)(nil),              // 7: bx2cloud.ContainerLogsResponse
+	(*timestamppb.Timestamp)(nil),              // 8: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                      // 9: google.protobuf.Empty
 }
 var file_container_proto_depIdxs = []int32{
-	6,  // 0: bx2cloud.Container.createdAt:type_name -> google.protobuf.Timestamp
-	6,  // 1: bx2cloud.Container.startedAt:type_name -> google.protobuf.Timestamp
+	8,  // 0: bx2cloud.Container.createdAt:type_name -> google.protobuf.Timestamp
+	8,  // 1: bx2cloud.Container.startedAt:type_name -> google.protobuf.Timestamp
 	4,  // 2: bx2cloud.ContainerExecRequest.initialization:type_name -> bx2cloud.ContainerExecInitializationRequest
 	0,  // 3: bx2cloud.ContainerExecInitializationRequest.identification:type_name -> bx2cloud.ContainerIdentificationRequest
-	0,  // 4: bx2cloud.ContainerService.Get:input_type -> bx2cloud.ContainerIdentificationRequest
-	7,  // 5: bx2cloud.ContainerService.List:input_type -> google.protobuf.Empty
-	1,  // 6: bx2cloud.ContainerService.Create:input_type -> bx2cloud.ContainerCreationRequest
-	0,  // 7: bx2cloud.ContainerService.Delete:input_type -> bx2cloud.ContainerIdentificationRequest
-	3,  // 8: bx2cloud.ContainerService.Exec:input_type -> bx2cloud.ContainerExecRequest
-	0,  // 9: bx2cloud.ContainerService.Start:input_type -> bx2cloud.ContainerIdentificationRequest
-	0,  // 10: bx2cloud.ContainerService.Stop:input_type -> bx2cloud.ContainerIdentificationRequest
-	2,  // 11: bx2cloud.ContainerService.Get:output_type -> bx2cloud.Container
-	2,  // 12: bx2cloud.ContainerService.List:output_type -> bx2cloud.Container
-	2,  // 13: bx2cloud.ContainerService.Create:output_type -> bx2cloud.Container
-	7,  // 14: bx2cloud.ContainerService.Delete:output_type -> google.protobuf.Empty
-	5,  // 15: bx2cloud.ContainerService.Exec:output_type -> bx2cloud.ContainerExecResponse
-	2,  // 16: bx2cloud.ContainerService.Start:output_type -> bx2cloud.Container
-	2,  // 17: bx2cloud.ContainerService.Stop:output_type -> bx2cloud.Container
-	11, // [11:18] is the sub-list for method output_type
-	4,  // [4:11] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	0,  // 4: bx2cloud.ContainerLogsRequest.identification:type_name -> bx2cloud.ContainerIdentificationRequest
+	0,  // 5: bx2cloud.ContainerService.Get:input_type -> bx2cloud.ContainerIdentificationRequest
+	9,  // 6: bx2cloud.ContainerService.List:input_type -> google.protobuf.Empty
+	1,  // 7: bx2cloud.ContainerService.Create:input_type -> bx2cloud.ContainerCreationRequest
+	0,  // 8: bx2cloud.ContainerService.Delete:input_type -> bx2cloud.ContainerIdentificationRequest
+	3,  // 9: bx2cloud.ContainerService.Exec:input_type -> bx2cloud.ContainerExecRequest
+	0,  // 10: bx2cloud.ContainerService.Start:input_type -> bx2cloud.ContainerIdentificationRequest
+	0,  // 11: bx2cloud.ContainerService.Stop:input_type -> bx2cloud.ContainerIdentificationRequest
+	6,  // 12: bx2cloud.ContainerService.Logs:input_type -> bx2cloud.ContainerLogsRequest
+	2,  // 13: bx2cloud.ContainerService.Get:output_type -> bx2cloud.Container
+	2,  // 14: bx2cloud.ContainerService.List:output_type -> bx2cloud.Container
+	2,  // 15: bx2cloud.ContainerService.Create:output_type -> bx2cloud.Container
+	9,  // 16: bx2cloud.ContainerService.Delete:output_type -> google.protobuf.Empty
+	5,  // 17: bx2cloud.ContainerService.Exec:output_type -> bx2cloud.ContainerExecResponse
+	2,  // 18: bx2cloud.ContainerService.Start:output_type -> bx2cloud.Container
+	2,  // 19: bx2cloud.ContainerService.Stop:output_type -> bx2cloud.Container
+	7,  // 20: bx2cloud.ContainerService.Logs:output_type -> bx2cloud.ContainerLogsResponse
+	13, // [13:21] is the sub-list for method output_type
+	5,  // [5:13] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_container_proto_init() }
@@ -630,7 +737,7 @@ func file_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_container_proto_rawDesc), len(file_container_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/api/pb/container.proto
+++ b/internal/api/pb/container.proto
@@ -14,6 +14,7 @@ service ContainerService {
     rpc Exec (stream ContainerExecRequest) returns (stream ContainerExecResponse);
     rpc Start (ContainerIdentificationRequest) returns (Container);
     rpc Stop (ContainerIdentificationRequest) returns (Container);
+    rpc Logs (ContainerLogsRequest) returns (stream ContainerLogsResponse);
 }
 
 message ContainerIdentificationRequest {
@@ -62,4 +63,13 @@ message ContainerExecResponse {
         bytes stdout = 1;
         int32 exit_code = 2;
     }
+}
+
+message ContainerLogsRequest {
+    ContainerIdentificationRequest identification = 1;
+    bool follow = 2;
+}
+
+message ContainerLogsResponse {
+    bytes content = 1;
 }

--- a/internal/cli/common/command.go
+++ b/internal/cli/common/command.go
@@ -25,7 +25,14 @@ func NewCliCommand(
 	argDescription string,
 	handler func(args []string, conn *grpc.ClientConn) (exits.ExitCode, error),
 ) *CliCommand {
-	return NewCliCommandWithFlags(name, description, argDescription, handler, func(fs *flag.FlagSet) {})
+	flagSet := flag.NewFlagSet(name, flag.ContinueOnError)
+
+	return &CliCommand{
+		description:    description,
+		argDescription: argDescription,
+		handler:        handler,
+		flagSet:        flagSet,
+	}
 }
 
 func NewCliCommandWithFlags(
@@ -41,7 +48,7 @@ func NewCliCommandWithFlags(
 
 	return &CliCommand{
 		description:    description,
-		argDescription: argDescription,
+		argDescription: fmt.Sprintf("[flags] %s", argDescription),
 		handler:        handler,
 		flagSet:        flagSet,
 	}
@@ -90,8 +97,6 @@ func (c *CliCommand) Execute(args []string, conn *grpc.ClientConn, cmdNameChain 
 	args = c.flagSet.Args()
 
 	if len(c.subcommands) == 0 {
-		// TODO: Pass flag data onto handler
-
 		if c.handler == nil {
 			fmt.Fprintf(os.Stderr, "This command does not have a handler attached to it, please report to the developer\n")
 			return exits.MISSING_SUBCOMMAND

--- a/internal/cli/container/commands.go
+++ b/internal/cli/container/commands.go
@@ -130,6 +130,23 @@ var Commands = []*common.CliCommand{
 					return exits.SUCCESS, nil
 				},
 			),
+			common.NewCliCommand(
+				"logs",
+				"Retrieves the logs of a specified container resource",
+				"<id>",
+				func(args []string, conn *grpc.ClientConn) (exits.ExitCode, error) {
+					client := pb.NewContainerServiceClient(conn)
+					id, exitCode, err := common.ParseUint32Arg(&args)
+					if err != nil {
+						return exitCode, fmt.Errorf("failed to parse 'id' argument: %w", err)
+					}
+
+					if err := Logs(client, id); err != nil {
+						return exits.CONTAINER_ERROR, err
+					}
+					return exits.SUCCESS, nil
+				},
+			),
 		},
 	),
 }

--- a/internal/cli/container/commands.go
+++ b/internal/cli/container/commands.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,12 @@ import (
 	"github.com/BenasB/bx2cloud/internal/cli/exits"
 	"google.golang.org/grpc"
 )
+
+var flags = struct {
+	follow bool
+}{
+	follow: true,
+}
 
 var Commands = []*common.CliCommand{
 	common.NewCliSubcommand(
@@ -130,7 +137,7 @@ var Commands = []*common.CliCommand{
 					return exits.SUCCESS, nil
 				},
 			),
-			common.NewCliCommand(
+			common.NewCliCommandWithFlags(
 				"logs",
 				"Retrieves the logs of a specified container resource",
 				"<id>",
@@ -141,10 +148,13 @@ var Commands = []*common.CliCommand{
 						return exitCode, fmt.Errorf("failed to parse 'id' argument: %w", err)
 					}
 
-					if err := Logs(client, id); err != nil {
+					if err := Logs(client, id, flags.follow); err != nil {
 						return exits.CONTAINER_ERROR, err
 					}
 					return exits.SUCCESS, nil
+				},
+				func(fs *flag.FlagSet) {
+					fs.BoolVar(&flags.follow, "f", false, "follow the log file")
 				},
 			),
 		},

--- a/internal/cli/container/commands.go
+++ b/internal/cli/container/commands.go
@@ -15,7 +15,7 @@ import (
 var flags = struct {
 	follow bool
 }{
-	follow: true,
+	follow: false,
 }
 
 var Commands = []*common.CliCommand{
@@ -154,7 +154,7 @@ var Commands = []*common.CliCommand{
 					return exits.SUCCESS, nil
 				},
 				func(fs *flag.FlagSet) {
-					fs.BoolVar(&flags.follow, "f", false, "follow the log file")
+					fs.BoolVar(&flags.follow, "f", flags.follow, "follow the log file")
 				},
 			),
 		},

--- a/internal/cli/container/handlers.go
+++ b/internal/cli/container/handlers.go
@@ -233,12 +233,12 @@ func Stop(client pb.ContainerServiceClient, id uint32) error {
 	return nil
 }
 
-func Logs(client pb.ContainerServiceClient, id uint32) error {
+func Logs(client pb.ContainerServiceClient, id uint32, follow bool) error {
 	req := &pb.ContainerLogsRequest{
 		Identification: &pb.ContainerIdentificationRequest{
 			Id: id,
 		},
-		Follow: false, // TODO: (This PR) pass follow from CLI flags
+		Follow: follow,
 	}
 
 	stream, err := client.Logs(context.Background(), req)

--- a/internal/cli/container/handlers.go
+++ b/internal/cli/container/handlers.go
@@ -232,3 +232,30 @@ func Stop(client pb.ContainerServiceClient, id uint32) error {
 
 	return nil
 }
+
+func Logs(client pb.ContainerServiceClient, id uint32) error {
+	req := &pb.ContainerLogsRequest{
+		Identification: &pb.ContainerIdentificationRequest{
+			Id: id,
+		},
+		Follow: false, // TODO: (This PR) pass follow from CLI flags
+	}
+
+	stream, err := client.Logs(context.Background(), req)
+	if err != nil {
+		return err
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(os.Stdout, string(resp.Content))
+	}
+
+	return nil
+}


### PR DESCRIPTION
Introduce functionality for storing and retrieving container logs

- Each container sets its `stdout` and `stderr` to a file in `/var/log/bx2cloud/<container_id>`
  - The log file is deleted once a container is deleted
  - The log file is retained when a container is stopped
  - The log file is truncated when a container is started again
- New `rpc Logs (ContainerLogsRequest) returns (stream ContainerLogsResponse);` definition in container service protobuf
  - Normally, the API just reads the full text file and streams it back to the gRPC client
  - Additionally, in `ContainerLogsRequest` the user can request to follow the logs, so in addition to returning the full text file, the API does not close the stream and instead tails the log file, sending any new logs to the gRPC client. This is implemented with [`inotify`](https://www.man7.org/linux/man-pages/man7/inotify.7.html)
- Added `container logs <id>` command to the CLI

```
$ bx2cloud container logs -h
bx2cloud container logs: Retrieves the logs of a specified container resource
usage: bx2cloud container logs [flags] <id>
flags:
  -f    follow the log file

$ bx2cloud container logs 1
<redacted>
Thu Jul 24 18:58:10 UTC 2025
Thu Jul 24 18:58:11 UTC 2025
Thu Jul 24 18:58:12 UTC 2025
$
```

- If a container is deleted when someone is performing `container logs -f <id>`, the stream exits and returns `log file no longer exists`.

<img width="555" height="540" alt="image" src="https://github.com/user-attachments/assets/891b28a0-7e5e-467e-9c36-2a8a0913c424" />

#### Unrelated changes

- Bump docusaurus to non-canary version
- Adjust CLI flag docs generation to better display types and default values
- Append `[flags]` to usage description of all CLI commands with flags
- Perform subnetwork existence check (non mutating operation) before stopping the container during `container destroy`